### PR TITLE
Fix graph loading bug, Clear out old measurements

### DIFF
--- a/src/Features/Metrics/Metric.tsx
+++ b/src/Features/Metrics/Metric.tsx
@@ -97,7 +97,7 @@ const MetricsContainer = () => {
     }
     if (!data && !subData) return;
     if (data && availableMetrics.length === 0) {
-      //short-circuit if we've got metrics
+      //only update state if we don't have metrics
       const { getMetrics } = data;
       dispatch(actions.allMetricsReceived(getMetrics));
     }

--- a/src/components/ChartingContainer.tsx
+++ b/src/components/ChartingContainer.tsx
@@ -17,8 +17,8 @@ const ChartingContainer = (props: any) => {
       <Grid container direction="row" justify="flex-start" alignItems="center" spacing={3}>
         {props.actives.map((activeMetric: Metric) => (
           <Grid item key={props.metrics.indexOf(activeMetric) || -1}>
-            {activeMetric.name.toLocaleUpperCase()} :{' '}
-            {activeMetric.historicalValues[activeMetric.historicalValues.length - 1].value || -1} {activeMetric.unit}
+            {activeMetric.name.toLocaleUpperCase()}:{' '}
+            {activeMetric.historicalValues.length >= 1 ? activeMetric.historicalValues[activeMetric.historicalValues.length - 1].value : -1} {activeMetric.unit}
             <LineChart
               width={400}
               height={400}


### PR DESCRIPTION
- Fixes a bug where if you tried to select a metric before we had received data for it, the charting component would break
- Remove old measurements (30 min ago) when we receive a new measurement by using array.filter